### PR TITLE
HotFix - Removed wildcard symbol for withGraphFetched queries

### DIFF
--- a/src/role/role.repository.ts
+++ b/src/role/role.repository.ts
@@ -16,7 +16,8 @@ export class RoleRepository implements Repository<number, Role> {
     }
 
     async findByName(name: string): Promise<Role>{
-        return await this.roleModel.query().findOne({name});
+        return await this.roleModel.query().findOne({name})
+        .withGraphFetched("[permissions, createdBy, updatedBy]");
     }
 
     async findAll(): Promise<Role[]> {

--- a/src/stock/stock.repository.ts
+++ b/src/stock/stock.repository.ts
@@ -22,7 +22,7 @@ export class StockRepository implements Repository<number, Stock> {
 
     async findAll(): Promise<Stock[]> {
         return await this.stockModel.query()
-            .withGraphFetched("*");
+        .withGraphFetched("[createdBy, updatedBy]");
     }
 
     async save(stock: Stock): Promise<Stock> {


### PR DESCRIPTION
Removed the wildcard symbol(*) an replaced with concrete relation names to avoid recursive infinite looping when during eager loading.